### PR TITLE
Fix E_DEPRECATED: Non-static method SASL2\SASL2::factory() should not be called statically

### DIFF
--- a/src/SASL2/SASL2.php
+++ b/src/SASL2/SASL2.php
@@ -66,7 +66,7 @@ class SASL2
     *                             SCRAM-* (any mechanism of the SCRAM family)
     *                     Types are not case sensitive
     */
-    function factory($type)
+    static public function factory($type)
     {
         $classname = 'SASL2\Auth\\';
         switch (strtolower($type)) {


### PR DESCRIPTION
E_DEPRECATED is occured because SASL2\SASL2::factory() is not static.
